### PR TITLE
Improve test coverage for service and controller layers

### DIFF
--- a/src/test/java/com/apiflows/controller/WorkflowControllerTest.java
+++ b/src/test/java/com/apiflows/controller/WorkflowControllerTest.java
@@ -1,6 +1,9 @@
 package com.apiflows.controller;
 
+import com.apiflows.exception.InvalidContentException;
+import com.apiflows.exception.UnexpectedErrorException;
 import com.apiflows.model.WorkflowsSpecificationView;
+import com.apiflows.service.WorkflowService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,6 +16,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 class WorkflowControllerTest {
@@ -38,6 +43,36 @@ class WorkflowControllerTest {
 
         assertEquals(HttpStatus.ACCEPTED, responseEntity.getStatusCode());
         assertTrue(responseEntity.getBody().getOpenAPIWorkflowParserResult().isYaml());
+    }
+
+    @Test
+    public void getFromContentWithComponents() throws Exception {
+        ResponseEntity<WorkflowsSpecificationView> responseEntity = workflowController.getFromContent(getContentFromFile());
+
+        assertEquals(HttpStatus.ACCEPTED, responseEntity.getStatusCode());
+        assertNotNull(responseEntity.getBody().getComponentsAsString());
+    }
+
+    @Test
+    public void getFromUrlThrowsInvalidContentException() throws Exception {
+        WorkflowService mockService = mock(WorkflowService.class);
+        when(mockService.getFromUrl(anyString())).thenThrow(new InvalidContentException("invalid"));
+
+        WorkflowController controller = new WorkflowController();
+        controller.setWorkflowService(mockService);
+
+        assertThrows(InvalidContentException.class, () -> controller.getFromUrl("https://example.com/bad.yaml"));
+    }
+
+    @Test
+    public void getFromContentThrowsUnexpectedErrorException() {
+        WorkflowService mockService = mock(WorkflowService.class);
+        when(mockService.getFromContent(anyString())).thenThrow(new UnexpectedErrorException());
+
+        WorkflowController controller = new WorkflowController();
+        controller.setWorkflowService(mockService);
+
+        assertThrows(UnexpectedErrorException.class, () -> controller.getFromContent("invalid content"));
     }
 
     String getContentFromFile() throws Exception {

--- a/src/test/java/com/apiflows/service/OpenApiOperationServiceTest.java
+++ b/src/test/java/com/apiflows/service/OpenApiOperationServiceTest.java
@@ -1,0 +1,69 @@
+package com.apiflows.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpenApiOperationServiceTest {
+
+    private OpenApiOperationService service = new OpenApiOperationService();
+
+    @Test
+    void isUrlWithHttps() {
+        assertTrue(service.isUrl("https://example.com/spec.yaml"));
+    }
+
+    @Test
+    void isUrlWithHttp() {
+        assertTrue(service.isUrl("http://example.com/spec.yaml"));
+    }
+
+    @Test
+    void isUrlWithRelativePath() {
+        assertFalse(service.isUrl("./pet-coupons.openapi.yaml"));
+    }
+
+    @Test
+    void isUrlNull() {
+        assertFalse(service.isUrl(null));
+    }
+
+    @Test
+    void extractExampleByName() {
+        assertEquals("MyExample", service.extractExampleByName("#/components/examples/MyExample"));
+    }
+
+    @Test
+    void extractExampleByNameSimplePath() {
+        assertEquals("petExample", service.extractExampleByName("/components/examples/petExample"));
+    }
+
+    @Test
+    void getRootFolderNull() {
+        assertEquals(".", service.getRootFolder(null));
+    }
+
+    @Test
+    void getRootFolderFromUrl() {
+        String root = service.getRootFolder("https://example.com/api/spec.yaml");
+        assertEquals("https://example.com/api/", root);
+    }
+
+    @Test
+    void getRootFolderFromAbsolutePath() {
+        String root = service.getRootFolder("/Users/beppe/project/spec.yaml");
+        assertEquals("/Users/beppe/project", root);
+    }
+
+    @Test
+    void getRootFolderFromRelativePath() {
+        String root = service.getRootFolder("src/test/resources/pet-coupons.arazzo.yaml");
+        assertEquals("src/test/resources", root);
+    }
+
+    @Test
+    void getRootFolderNoParent() {
+        String root = service.getRootFolder("spec.yaml");
+        assertNull(root);
+    }
+}

--- a/src/test/java/com/apiflows/service/WorkflowServiceTest.java
+++ b/src/test/java/com/apiflows/service/WorkflowServiceTest.java
@@ -1,0 +1,117 @@
+package com.apiflows.service;
+
+import com.apiflows.exception.InvalidContentException;
+import com.apiflows.exception.UnexpectedErrorException;
+import com.apiflows.model.WorkflowsSpecificationView;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class WorkflowServiceTest {
+
+    private WorkflowService service;
+    private FileService fileService;
+
+    @BeforeEach
+    void setUp() {
+        service = new WorkflowService();
+        fileService = mock(FileService.class);
+        service.setFileService(fileService);
+    }
+
+    @Test
+    void getFromContentWithValidYaml() throws Exception {
+        String content = getContentFromFile("src/test/resources/pet-coupons.arazzo.yaml");
+
+        WorkflowsSpecificationView view = service.getFromContent(content);
+
+        assertNotNull(view);
+        assertNotNull(view.getOpenAPIWorkflowParserResult());
+        assertNotNull(view.getOpenAPIWorkflowParserResult().getOpenAPIWorkflow());
+        assertEquals("Petstore - Apply Coupons", view.getOpenAPIWorkflowParserResult().getOpenAPIWorkflow().getInfo().getTitle());
+    }
+
+    @Test
+    void getFromContentWithComponentsAsString() throws Exception {
+        String content = getContentFromFile("src/test/resources/pet-coupons.arazzo.yaml");
+
+        WorkflowsSpecificationView view = service.getFromContent(content);
+
+        assertNotNull(view.getComponentsAsString());
+    }
+
+    @Test
+    void getFromUrlWithRealFile() throws Exception {
+        String filePath = Paths.get("src/test/resources/pet-coupons.arazzo.yaml").toAbsolutePath().toString();
+        String content = getContentFromFile("src/test/resources/pet-coupons.arazzo.yaml");
+
+        when(fileService.call(filePath)).thenReturn(content);
+        when(fileService.isValidJson(content)).thenReturn(false);
+        when(fileService.isValidYaml(content)).thenReturn(true);
+
+        WorkflowsSpecificationView view = service.getFromUrl(filePath);
+
+        assertNotNull(view);
+        assertNotNull(view.getOpenAPIWorkflowParserResult().getOpenAPIWorkflow());
+        assertEquals("Petstore - Apply Coupons", view.getOpenAPIWorkflowParserResult().getOpenAPIWorkflow().getInfo().getTitle());
+    }
+
+    @Test
+    void getFromUrlThrowsInvalidContentException() {
+        String url = "https://example.com/spec.yaml";
+        String invalidContent = "this is not valid yaml or json content for arazzo";
+
+        when(fileService.call(url)).thenReturn(invalidContent);
+        when(fileService.isValidJson(invalidContent)).thenReturn(false);
+        when(fileService.isValidYaml(invalidContent)).thenReturn(false);
+
+        assertThrows(InvalidContentException.class, () -> service.getFromUrl(url));
+    }
+
+    @Test
+    void getFromUrlThrowsUnexpectedErrorWhenContentIsNull() {
+        String url = "https://example.com/spec.yaml";
+        String emptyContent = "";
+
+        when(fileService.call(url)).thenReturn(emptyContent);
+        when(fileService.isValidJson(emptyContent)).thenReturn(false);
+        when(fileService.isValidYaml(emptyContent)).thenReturn(false);
+
+        assertThrows(InvalidContentException.class, () -> service.getFromUrl(url));
+    }
+
+    @Test
+    void getFromContentNoComponentsWhenAbsent() throws Exception {
+        String content = "arazzo: 1.0.0\n" +
+                "info:\n" +
+                "  title: minimal\n" +
+                "  version: v1\n" +
+                "sourceDescriptions:\n" +
+                "  - name: petstore\n" +
+                "    url: https://petstore3.swagger.io/api/v3/openapi.json\n" +
+                "    type: openapi\n" +
+                "workflows:\n" +
+                "  - workflowId: test-workflow\n" +
+                "    steps:\n" +
+                "      - stepId: step-one\n" +
+                "        operationId: listPets\n";
+
+        WorkflowsSpecificationView view = service.getFromContent(content);
+
+        assertNotNull(view);
+        assertNull(view.getComponentsAsString());
+    }
+
+    private String getContentFromFile(String filePath) throws Exception {
+        Path fullPath = Paths.get(filePath).toAbsolutePath();
+        byte[] encodedBytes = Files.readAllBytes(fullPath);
+        return new String(encodedBytes, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
## Summary

Improves unit test coverage from 18 to 38 tests by adding tests for previously untested classes.

### New test classes
- **`OpenApiOperationServiceTest`** — covers `isUrl`, `extractExampleByName`, and `getRootFolder` with various inputs
- **`WorkflowServiceTest`** — covers `getFromContent` and `getFromUrl` scenarios using Mockito to mock `FileService`

### Extended test class
- **`WorkflowControllerTest`** — adds tests for components assertion and exception propagation (`InvalidContentException`, `UnexpectedErrorException`)

Also updates the `openapi-workflow-parser` dependency to `0.0.5-SNAPSHOT`.